### PR TITLE
Fixup reboot confirmation on tablets

### DIFF
--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -462,7 +462,7 @@
 
     <!-- Reboot Confirmation Dialog.  When the user chooses to reboot the device, there will
          be a confirmation dialog.  This is the message. -->
-    <string name="reboot_confirm" product="tablet">Your tablet will reboot.</string>
+    <!-- <string name="reboot_confirm" product="tablet">Your tablet will reboot.</string> -->
 
     <!-- Recent Tasks dialog: title
      TODO: this should move to SystemUI.apk, but the code for the old


### PR DESCRIPTION
String already defined in: frameworks/base/core/res/res/values/chroma_strings.xml
