### PR TITLE
Download: Add support to manually pause/resume download

### DIFF
--- a/core/java/android/app/DownloadManager.java
+++ b/core/java/android/app/DownloadManager.java
@@ -280,6 +280,13 @@ public class DownloadManager {
      */
     public final static int PAUSED_UNKNOWN = 4;
 
+   /**
+    * Value of {@link #COLUMN_REASON} when the download is paused manually.
+    *
+    * @hide
+    */
+    public final static int PAUSED_MANUAL = 5;
+
     /**
      * Broadcast intent action sent by the download manager when a download completes.
      */
@@ -922,6 +929,7 @@ public class DownloadManager {
                     parts.add(statusClause("=", Downloads.Impl.STATUS_WAITING_TO_RETRY));
                     parts.add(statusClause("=", Downloads.Impl.STATUS_WAITING_FOR_NETWORK));
                     parts.add(statusClause("=", Downloads.Impl.STATUS_QUEUED_FOR_WIFI));
+                    parts.add(statusClause("=", Downloads.Impl.STATUS_PAUSED_MANUAL));
                 }
                 if ((mStatusFlags & STATUS_SUCCESSFUL) != 0) {
                     parts.add(statusClause("=", Downloads.Impl.STATUS_SUCCESS));
@@ -1170,6 +1178,34 @@ public class DownloadManager {
         values.put(Downloads.Impl.COLUMN_CONTROL, Downloads.Impl.CONTROL_RUN);
         values.put(Downloads.Impl.COLUMN_BYPASS_RECOMMENDED_SIZE_LIMIT, 1);
         mResolver.update(mBaseUri, values, getWhereClauseForIds(ids), getWhereArgsForIds(ids));
+    }
+
+    /**
+     * Pause the given running download manually.
+     *
+     * @param id the ID of the download to be paused
+     * @return the number of downloads actually updated
+     * @hide
+     */
+    public int pauseDownload(long id) {
+        ContentValues values = new ContentValues();
+        values.put(Downloads.Impl.COLUMN_STATUS, Downloads.Impl.STATUS_PAUSED_MANUAL);
+
+        return mResolver.update(ContentUris.withAppendedId(mBaseUri, id), values, null, null);
+    }
+
+    /**
+     * Resume the given paused download manually.
+     *
+     * @param id the ID of the download to be resumed
+     * @return the number of downloads actually updated
+     * @hide
+     */
+    public int resumeDownload(long id) {
+       ContentValues values = new ContentValues();
+       values.put(Downloads.Impl.COLUMN_STATUS, Downloads.Impl.STATUS_RUNNING);
+
+       return mResolver.update(ContentUris.withAppendedId(mBaseUri, id), values, null, null);
     }
 
     /**
@@ -1546,6 +1582,9 @@ public class DownloadManager {
                 case Downloads.Impl.STATUS_QUEUED_FOR_WIFI:
                     return PAUSED_QUEUED_FOR_WIFI;
 
+                case Downloads.Impl.STATUS_PAUSED_MANUAL:
+                    return PAUSED_MANUAL;
+
                 default:
                     return PAUSED_UNKNOWN;
             }
@@ -1601,6 +1640,7 @@ public class DownloadManager {
                 case Downloads.Impl.STATUS_WAITING_TO_RETRY:
                 case Downloads.Impl.STATUS_WAITING_FOR_NETWORK:
                 case Downloads.Impl.STATUS_QUEUED_FOR_WIFI:
+                case Downloads.Impl.STATUS_PAUSED_MANUAL:
                     return STATUS_PAUSED;
 
                 case Downloads.Impl.STATUS_SUCCESS:

--- a/core/java/android/provider/Downloads.java
+++ b/core/java/android/provider/Downloads.java
@@ -598,6 +598,11 @@ public final class Downloads {
         public static final int STATUS_QUEUED_FOR_WIFI = 196;
 
         /**
+         * This download is paused manually.
+         */
+        public static final int STATUS_PAUSED_MANUAL = 197;
+
+        /**
          * This download couldn't be completed due to insufficient storage
          * space.  Typically, this is because the SD card is full.
          */


### PR DESCRIPTION
Add the pause and resume APIs here so that applications can
pause and resume downloads manually through DownloadManager.

This patch consists of 2 changes:
1. Add pause and resume download APIs
2. Add another paused reason for this download status

Change-Id: I606b48ca20f43bcc6c119683818c2ab6ff03bfe5
