### PR TITLE
native: Restore VM memory overrides

### DIFF
--- a/build/phone-xxhdpi-2048-dalvik-heap.mk
+++ b/build/phone-xxhdpi-2048-dalvik-heap.mk
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2012 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the Dalvik heap for a 2G phone
+# 192m of RAM gives enough space for 5 8 megapixel camera bitmaps in RAM.
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapstartsize=16m \
+    dalvik.vm.heapgrowthlimit=192m \
+    dalvik.vm.heapsize=512m \
+    dalvik.vm.heaptargetutilization=0.75 \
+    dalvik.vm.heapminfree=2m \
+    dalvik.vm.heapmaxfree=8m

--- a/build/phone-xxhdpi-2048-hwui-memory.mk
+++ b/build/phone-xxhdpi-2048-hwui-memory.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2013 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the HWUI memory limits
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hwui.texture_cache_size=72 \
+    ro.hwui.layer_cache_size=48 \
+    ro.hwui.r_buffer_cache_size=8 \
+    ro.hwui.path_cache_size=32 \
+    ro.hwui.gradient_cache_size=1 \
+    ro.hwui.drop_shadow_cache_size=6 \
+    ro.hwui.texture_cache_flushrate=0.4 \
+    ro.hwui.text_small_cache_width=1024 \
+    ro.hwui.text_small_cache_height=1024 \
+    ro.hwui.text_large_cache_width=2048 \
+    ro.hwui.text_large_cache_height=1024

--- a/build/phone-xxhdpi-3072-dalvik-heap.mk
+++ b/build/phone-xxhdpi-3072-dalvik-heap.mk
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2016 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the Dalvik heap for a 3G phone
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapstartsize=8m \
+    dalvik.vm.heapgrowthlimit=288m \
+    dalvik.vm.heapsize=768m \
+    dalvik.vm.heaptargetutilization=0.75 \
+    dalvik.vm.heapminfree=512k \
+    dalvik.vm.heapmaxfree=8m

--- a/build/phone-xxhdpi-3072-hwui-memory.mk
+++ b/build/phone-xxhdpi-3072-hwui-memory.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2016 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the HWUI memory limits
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hwui.texture_cache_size=72 \
+    ro.hwui.layer_cache_size=48 \
+    ro.hwui.path_cache_size=32 \
+    ro.hwui.gradient_cache_size=1 \
+    ro.hwui.drop_shadow_cache_size=6 \
+    ro.hwui.r_buffer_cache_size=8 \
+    ro.hwui.texture_cache_flushrate=0.4 \
+    ro.hwui.text_small_cache_width=1024 \
+    ro.hwui.text_small_cache_height=1024 \
+    ro.hwui.text_large_cache_width=2048 \
+    ro.hwui.text_large_cache_height=1024

--- a/build/phone-xxxhdpi-3072-dalvik-heap.mk
+++ b/build/phone-xxxhdpi-3072-dalvik-heap.mk
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2015 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the Dalvik heap for a 3G phone
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapstartsize=8m \
+    dalvik.vm.heapgrowthlimit=288m \
+    dalvik.vm.heapsize=768m \
+    dalvik.vm.heaptargetutilization=0.75 \
+    dalvik.vm.heapminfree=2m \
+    dalvik.vm.heapmaxfree=8m

--- a/build/phone-xxxhdpi-3072-hwui-memory.mk
+++ b/build/phone-xxxhdpi-3072-hwui-memory.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2015 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the HWUI memory limits
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hwui.texture_cache_size=88 \
+    ro.hwui.layer_cache_size=58 \
+    ro.hwui.path_cache_size=32 \
+    ro.hwui.shape_cache_size=4 \
+    ro.hwui.gradient_cache_size=2 \
+    ro.hwui.drop_shadow_cache_size=8 \
+    ro.hwui.r_buffer_cache_size=8 \
+    ro.hwui.text_small_cache_width=2048 \
+    ro.hwui.text_small_cache_height=2048 \
+    ro.hwui.text_large_cache_width=4096 \
+    ro.hwui.text_large_cache_height=4096


### PR DESCRIPTION
This change adds back the property overrides for several device
types as we had in CM 11.

It contains a squashed commit of the following:

Author: Steve Kondik <shade@chemlab.org>
Date:   Sat Jan 4 12:12:00 2014 -0800

    Update HWUI config for xxhdpi/2GB devices

Author: Steve Kondik <shade@chemlab.org>
Date:   Tue Aug 6 02:53:19 2013 -0700

    hwui: Update configuration for 2GB/1080p devices

Author: Steve Kondik <shade@chemlab.org>
Date:   Sat Jun 1 14:51:17 2013 +0200

    provide overrides for hwui memory limits for xxhdpi phones

Author: Steve Kondik <shade@chemlab.org>
Date:   Fri May 17 13:10:19 2013 -0700

    Add heap configuration for 1080p phones with 2048m

     * Increase heap start size to 16m to minimize GC with larger bitmaps

Author: Andrew Bartholomew <andrewb03@gmail.com>
Date:   Thu Apr 25 13:48:21 2013 -0400

    build/phone-xhdpi-1024-dalvik-heap.mk Revert AOSP heapgrowthlimit change from 64 to 96

    This reverts part of AOSP change at

    https://android.googlesource.com/platform/frameworks/native/+/c84e9844d621223d14178be521

    Possible performance issues have arisen because of it. Discussion at

    http://code.google.com/p/android/issues/detail?id=40961

Author: Bhargav Upperla <bhargavuln@codeaurora.org>
Date:   Thu May 23 12:50:15 2013 -0700

    Configure dalvik heap parameters for low memory devices

    Reduces after boot memory footprint by about 5-8MB
    Note: This is for low memory based devices only (~512MB RAM
    or less)

Author: bmc08gt <brandon.mcansh@gmail.com>
Date:   Fri, 20 Mar 2015 15:14:07 +0100

    Add HWUI overrides for xxxhdpi phone

  Change-Id: I4393ef0a5f6f1e9775b5d40b094da3f74ed3ae35
  Signed-off-by: bmc08gt <brandon.mcansh@gmail.com>

Author: bmc08gt <brandon.mcansh@gmail.com>
Date:   Fri, 20 Mar 2015 15:19:19 +0100

    Add dalvik heap override for xxxhdpi phone

  Change-Id: Ib2649f55327775bbd4d94012952b4301536391ed
  Signed-off-by: bmc08gt <brandon.mcansh@gmail.com>

Author: Louis Popi <theh2o64@gmail.com>
Date:   Wed, 11 May 2016 22:48:52 +0200

    Add dalvik heap/hwui overrides for xxhdpi phone with 3072MB RAM

  Change-Id: I0ebf2033341e8f09004c1e2dec5f4438aa52e5dc

Change-Id: Id7e1967d18227359ad9631139bfd47e61e494829