### PR TITLE
Don't refresh ui when screen off

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
@@ -54,6 +54,10 @@ public class KeyguardStatusView extends GridLayout {
     private TextView mOwnerInfo;
     private ViewGroup mClockContainer;
     private ChargingView mBatteryDoze;
+    //On the first boot, keygard will start to receiver TIME_TICK intent.
+    //And onScreenTurnedOff will not get called if power off when keyguard is not started.
+    //Set initial value to false to skip the above case.
+    private boolean mEnableRefresh = false;
 
     //On the first boot, keygard will start to receiver TIME_TICK intent.
     //And onScreenTurnedOff will not get called if power off when keyguard is not started.


### PR DESCRIPTION
KeyguardStatusView is doing refresh all the time,
which cause high power when screen off

PatchSet:
- We turn of the refresh when screen is off which is a good
  idea. But we should force latest next refresh when screen turns
  on. Du that a timechanged refresh maybe comes a bit later.